### PR TITLE
Gracefully skip unknown emoji aliases in `emojify`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dawran6/emoji "0.1.5"
+(defproject dawran6/emoji "0.1.6"
   :description "Emoji for Clojure"
   :url "http://github.com/dawran6/emoji"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dawran6/emoji "0.1.6"
+(defproject dawran6/emoji "0.1.5"
   :description "Emoji for Clojure"
   :url "http://github.com/dawran6/emoji"
   :license {:name "MIT"

--- a/src/emoji/core.clj
+++ b/src/emoji/core.clj
@@ -41,7 +41,9 @@
   [s]
   (string/replace s
                   #"(:)([-+\w]+)(:)"
-                  (fn [[_ delimeter_1 alias delimeter_2]] (-> alias ->emoji))))
+                  (fn [[original _delimeter_1 alias _delimeter_2]]
+                    (let [emoji (-> alias ->emoji)]
+                      (if (nil? emoji) original emoji)))))
 
 (defn emojify-all
   "Replace every word in a sentence to emoji if it is an alias.

--- a/src/emoji/core.clj
+++ b/src/emoji/core.clj
@@ -43,7 +43,7 @@
                   #"(:)([-+\w]+)(:)"
                   (fn [[original _delimeter_1 alias _delimeter_2]]
                     (let [emoji (-> alias ->emoji)]
-                      (if (nil? emoji) original emoji)))))
+                      (or emoji original)))))
 
 (defn emojify-all
   "Replace every word in a sentence to emoji if it is an alias.

--- a/test/emoji/core_test.clj
+++ b/test/emoji/core_test.clj
@@ -14,6 +14,11 @@
     (is (= (emoji/emojify "Sending :e-mail:...")
            "Sending 📧..."))))
 
+(deftest emojify-test-with-invalid-alias-present
+  (testing "Sentence with characters that match the emoji alias pattern but do not represent an emoji"
+    (is (= (emoji/emojify ":package: Package was delivered at 2025-06-26T23:21:00.000Z")
+           "📦 Package was delivered at 2025-06-26T23:21:00.000Z"))))
+
 (deftest emojify-all-test
   (testing "Regular sentence with no intention to use emoji"
     (is (= (emoji/emojify-all "Sending e-mail with a smile")


### PR DESCRIPTION
@dawranliou Hello! Thanks for creating this library. It's been a helpful tool for me.

One issue I have run into is that `emoijify` throws errors if the input string contains anything that matches `(:)([-+\w]+)(:)` without the inner value being a valid emoji alias. 

```
; Execution error (NullPointerException) at java.util.regex.Matcher/quoteReplacement (Matcher.java:849).
; Cannot invoke "String.indexOf(int)" because "s" is null
```
This is thrown by the `clojure.string/replace` call because the provided replacement function in `emojify` returns the result of `->emoji` which returns nil if the input isn't a valid emoji alias.

I noticed this when running an email body through the `emojify` call that contained an ISO timestamp `2025-06-26T23:21:00.000Z`. Passing "21" into `->emoji` returns nil resulting in an error being thrown.

### Changes

This PR just adds support for this use case by ignoring emoji formatted text that does not map to a real emoji within the string/replace call.